### PR TITLE
Improve Salesforce deal manager UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Cv
+
+## Deal Manager LWC
+
+This repository now includes a Lightning Web Component for managing deals and bank requests in Salesforce.
+
+The component is located in `force-app/main/default/lwc/dealManager`. It displays opportunities in a table with actions to create new bank requests, view existing requests, and update the deal stage. Users can change deal stages and case statuses using intuitive modals for a smoother experience.
+
+When a modal closes, input fields are cleared so a new request always starts with blank values.
+
+The Apex controller `DealController` provides server-side logic to query opportunities and related cases, create new cases, and update records.
+
+To use this component, deploy the `force-app` directory to your Salesforce org using `sfdx force:source:deploy`.

--- a/force-app/main/default/classes/DealController.cls
+++ b/force-app/main/default/classes/DealController.cls
@@ -1,0 +1,82 @@
+public with sharing class DealController {
+    @AuraEnabled(cacheable=true)
+    public static List<DealWrapper> getDeals(String stageFilter) {
+        String stage = String.isBlank(stageFilter) ? null : stageFilter;
+        List<Opportunity> opps = [
+            SELECT Id, Name, StageName, CreatedDate, Owner.Name,
+                   Primary_Contact__r.Phone, Primary_Contact__r.Email
+            FROM Opportunity
+            WHERE (:stage == null OR StageName = :stage)
+            ORDER BY CreatedDate DESC
+            LIMIT 200
+        ];
+        Map<Id, List<Case>> oppCases = new Map<Id, List<Case>>();
+        for (Case c : [SELECT Id, Subject, Status, AccountId, CreatedDate, Opportunity__c
+                        FROM Case
+                        WHERE Opportunity__c IN :opps]) {
+            if (!oppCases.containsKey(c.Opportunity__c)) {
+                oppCases.put(c.Opportunity__c, new List<Case>());
+            }
+            oppCases.get(c.Opportunity__c).add(c);
+        }
+        List<DealWrapper> wrappers = new List<DealWrapper>();
+        for (Opportunity o : opps) {
+            DealWrapper w = new DealWrapper();
+            w.opportunityId = o.Id;
+            w.name = o.Name;
+            w.stage = o.StageName;
+            w.createdDate = o.CreatedDate;
+            w.ownerName = o.Owner.Name;
+            w.contactPhone = o.Primary_Contact__r != null ? o.Primary_Contact__r.Phone : null;
+            w.contactEmail = o.Primary_Contact__r != null ? o.Primary_Contact__r.Email : null;
+            w.cases = oppCases.containsKey(o.Id) ? oppCases.get(o.Id) : new List<Case>();
+            wrappers.add(w);
+        }
+        return wrappers;
+    }
+
+    @AuraEnabled
+    public static Id createBankRequest(Id opportunityId, Id bankAccountId, List<Id> ccUserIds,
+                                       String subject, String body) {
+        Case c = new Case();
+        c.Opportunity__c = opportunityId;
+        c.AccountId = bankAccountId;
+        c.Subject = subject;
+        c.Description = body;
+        insert c;
+        if (ccUserIds != null) {
+            List<Task> tasks = new List<Task>();
+            for (Id uid : ccUserIds) {
+                Task t = new Task(WhatId=c.Id, OwnerId=uid, Subject='Bank Request CC');
+                tasks.add(t);
+            }
+            if (!tasks.isEmpty()) insert tasks;
+        }
+        return c.Id;
+    }
+
+    @AuraEnabled
+    public static void updateDealStage(Id opportunityId, String newStage) {
+        Opportunity opp = [SELECT Id, StageName FROM Opportunity WHERE Id=:opportunityId LIMIT 1];
+        opp.StageName = newStage;
+        update opp;
+    }
+
+    @AuraEnabled
+    public static void updateCaseStatus(Id caseId, String newStatus) {
+        Case c = [SELECT Id, Status FROM Case WHERE Id=:caseId LIMIT 1];
+        c.Status = newStatus;
+        update c;
+    }
+
+    public class DealWrapper {
+        @AuraEnabled public Id opportunityId;
+        @AuraEnabled public String name;
+        @AuraEnabled public String stage;
+        @AuraEnabled public DateTime createdDate;
+        @AuraEnabled public String ownerName;
+        @AuraEnabled public String contactPhone;
+        @AuraEnabled public String contactEmail;
+        @AuraEnabled public List<Case> cases;
+    }
+}

--- a/force-app/main/default/classes/DealController.cls-meta.xml
+++ b/force-app/main/default/classes/DealController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/dealManager/dealManager.css
+++ b/force-app/main/default/lwc/dealManager/dealManager.css
@@ -1,0 +1,4 @@
+.stage-Prospecting { background-color: #fff7ce; }
+.stage-Qualification { background-color: #d8f8e1; }
+.stage-ClosedWon { background-color: #c8e6c9; }
+.stage-ClosedLost { background-color: #f9d5d3; }

--- a/force-app/main/default/lwc/dealManager/dealManager.html
+++ b/force-app/main/default/lwc/dealManager/dealManager.html
@@ -1,0 +1,96 @@
+<template>
+    <lightning-card title="Deal Manager">
+        <div class="slds-m-around_medium">
+            <lightning-combobox label="Filter by Stage" value={stageFilter}
+                                 options={stageOptions} onchange={handleStageFilter} ></lightning-combobox>
+            <lightning-datatable key-field="opportunityId"
+                                data={deals}
+                                columns={columns}
+                                onrowaction={handleRowAction}
+                                hide-checkbox-column="true"
+                                class="slds-m-top_medium">
+            </lightning-datatable>
+        </div>
+    </lightning-card>
+
+    <template if:true={showRequestModal}>
+        <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open">
+            <div class="slds-modal__container">
+                <header class="slds-modal__header">
+                    <h2 class="slds-text-heading_medium">New Bank Request</h2>
+                </header>
+                <div class="slds-modal__content slds-p-around_medium">
+                    <lightning-input label="Bank" value={bank} onchange={handleBankChange}></lightning-input>
+                    <lightning-input label="CC User Ids (comma separated)" value={ccUsers} onchange={handleCcChange}></lightning-input>
+                    <lightning-input label="Subject" value={subject} onchange={handleSubjectChange}></lightning-input>
+                    <lightning-textarea label="Body" value={body} onchange={handleBodyChange}></lightning-textarea>
+                </div>
+                <footer class="slds-modal__footer">
+                    <lightning-button variant="neutral" label="Cancel" onclick={closeRequestModal}></lightning-button>
+                    <lightning-button variant="brand" label="Send" onclick={sendRequest}></lightning-button>
+                </footer>
+            </div>
+        </section>
+        <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
+
+    <template if:true={showStageModal}>
+        <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open">
+            <div class="slds-modal__container">
+                <header class="slds-modal__header">
+                    <h2 class="slds-text-heading_medium">Change Deal Stage</h2>
+                </header>
+                <div class="slds-modal__content slds-p-around_medium">
+                    <lightning-combobox label="Stage" value={newStage} options={stageOptions} onchange={handleStageChange}></lightning-combobox>
+                </div>
+                <footer class="slds-modal__footer">
+                    <lightning-button variant="neutral" label="Cancel" onclick={closeStageModal}></lightning-button>
+                    <lightning-button variant="brand" label="Save" onclick={saveStage}></lightning-button>
+                </footer>
+            </div>
+        </section>
+        <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
+
+    <template if:true={showStatusModal}>
+        <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open">
+            <div class="slds-modal__container">
+                <header class="slds-modal__header">
+                    <h2 class="slds-text-heading_medium">Update Case Status</h2>
+                </header>
+                <div class="slds-modal__content slds-p-around_medium">
+                    <lightning-combobox label="Status" value={newStatus} options={statusOptions} onchange={handleStatusChange}></lightning-combobox>
+                </div>
+                <footer class="slds-modal__footer">
+                    <lightning-button variant="neutral" label="Cancel" onclick={closeStatusModal}></lightning-button>
+                    <lightning-button variant="brand" label="Save" onclick={saveStatus}></lightning-button>
+                </footer>
+            </div>
+        </section>
+        <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
+
+    <template if:true={showCaseModal}>
+        <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open">
+            <div class="slds-modal__container">
+                <header class="slds-modal__header">
+                    <h2 class="slds-text-heading_medium">Bank Requests</h2>
+                </header>
+                <div class="slds-modal__content slds-p-around_medium">
+                    <template if:true={selectedDeal.cases.length}>
+                        <lightning-datatable key-field="Id" data={selectedDeal.cases}
+                            columns={caseColumns} onrowaction={handleCaseAction}
+                            hide-checkbox-column="true"></lightning-datatable>
+                    </template>
+                    <template if:false={selectedDeal.cases.length}>
+                        <p>No bank requests found.</p>
+                    </template>
+                </div>
+                <footer class="slds-modal__footer">
+                    <lightning-button variant="neutral" label="Close" onclick={closeCaseModal}></lightning-button>
+                </footer>
+            </div>
+        </section>
+        <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
+</template>

--- a/force-app/main/default/lwc/dealManager/dealManager.js
+++ b/force-app/main/default/lwc/dealManager/dealManager.js
@@ -1,0 +1,190 @@
+import { LightningElement, wire, track } from 'lwc';
+import getDeals from '@salesforce/apex/DealController.getDeals';
+import createBankRequest from '@salesforce/apex/DealController.createBankRequest';
+import updateDealStage from '@salesforce/apex/DealController.updateDealStage';
+import updateCaseStatus from '@salesforce/apex/DealController.updateCaseStatus';
+
+const COLUMNS = [
+    { label: 'Deal Name', fieldName: 'name', type: 'text' },
+    { label: 'Phone', fieldName: 'contactPhone', type: 'phone' },
+    { label: 'Email', fieldName: 'contactEmail', type: 'email' },
+    { label: 'Owner', fieldName: 'ownerName', type: 'text' },
+    { label: 'Created', fieldName: 'createdDate', type: 'date' },
+    { label: 'Stage', fieldName: 'stage', type: 'text', cellAttributes: { class: { fieldName: 'stageClass' } } },
+    {
+        type: 'action',
+        typeAttributes: { rowActions: [
+            { label: 'New Bank Request', name: 'new_request' },
+            { label: 'View Requests', name: 'view_requests' },
+            { label: 'Change Stage', name: 'change_stage' }
+        ]}
+    }
+];
+
+const CASE_COLUMNS = [
+    { label: 'Subject', fieldName: 'Subject', type: 'text' },
+    { label: 'Status', fieldName: 'Status', type: 'text' },
+    { label: 'Created', fieldName: 'CreatedDate', type: 'date' },
+    {
+        type: 'action',
+        typeAttributes: { rowActions: [ { label: 'Update Status', name: 'update_status' } ] }
+    }
+];
+
+export default class DealManager extends LightningElement {
+    @track deals = [];
+    @track stageFilter = '';
+    @track showRequestModal = false;
+    @track showCaseModal = false;
+    @track showStageModal = false;
+    @track showStatusModal = false;
+    @track selectedDeal = {};
+    selectedCaseId;
+
+    newStage;
+    newStatus;
+
+    bank;
+    ccUsers;
+    subject;
+    body;
+
+    columns = COLUMNS;
+    caseColumns = CASE_COLUMNS;
+
+    stageOptions = [
+        { label: 'All', value: '' },
+        { label: 'Prospecting', value: 'Prospecting' },
+        { label: 'Qualification', value: 'Qualification' },
+        { label: 'Closed Won', value: 'Closed Won' },
+        { label: 'Closed Lost', value: 'Closed Lost' }
+    ];
+
+    statusOptions = [
+        { label: 'New', value: 'New' },
+        { label: 'In Progress', value: 'In Progress' },
+        { label: 'Completed', value: 'Completed' },
+        { label: 'Closed', value: 'Closed' }
+    ];
+
+    @wire(getDeals, { stageFilter: '$stageFilter' })
+    wiredDeals({ error, data }) {
+        if (data) {
+            this.deals = data.map(d => {
+                return { ...d, stageClass: 'stage-' + d.stage.replace(/\s/g, '') };
+            });
+        } else if (error) {
+            // eslint-disable-next-line no-console
+            console.error(error);
+        }
+    }
+
+    handleStageFilter(event) {
+        this.stageFilter = event.detail.value;
+    }
+
+    handleRowAction(event) {
+        const action = event.detail.action.name;
+        const row = event.detail.row;
+        this.selectedDeal = row;
+        if (action === 'new_request') {
+            this.bank = '';
+            this.ccUsers = '';
+            this.subject = row.name;
+            this.body = '';
+            this.showRequestModal = true;
+        } else if (action === 'view_requests') {
+            this.showCaseModal = true;
+        } else if (action === 'change_stage') {
+            this.newStage = row.stage;
+            this.showStageModal = true;
+        }
+    }
+
+    handleCaseAction(event) {
+        const action = event.detail.action.name;
+        const row = event.detail.row;
+        if (action === 'update_status') {
+            this.selectedCaseId = row.Id;
+            this.newStatus = row.Status;
+            this.showStatusModal = true;
+        }
+    }
+
+    handleBankChange(event) {
+        this.bank = event.detail.value;
+    }
+    handleCcChange(event) {
+        this.ccUsers = event.detail.value;
+    }
+    handleSubjectChange(event) {
+        this.subject = event.detail.value;
+    }
+    handleBodyChange(event) {
+        this.body = event.detail.value;
+    }
+
+    closeRequestModal() {
+        this.showRequestModal = false;
+        this.bank = '';
+        this.ccUsers = '';
+        this.subject = '';
+        this.body = '';
+    }
+    closeCaseModal() {
+        this.showCaseModal = false;
+        this.selectedCaseId = null;
+    }
+    closeStageModal() {
+        this.showStageModal = false;
+        this.newStage = null;
+    }
+    closeStatusModal() {
+        this.showStatusModal = false;
+        this.newStatus = null;
+    }
+
+    handleStageChange(event) {
+        this.newStage = event.detail.value;
+    }
+    handleStatusChange(event) {
+        this.newStatus = event.detail.value;
+    }
+
+    saveStage() {
+        updateDealStage({ opportunityId: this.selectedDeal.opportunityId, newStage: this.newStage })
+            .then(() => {
+                this.showStageModal = false;
+                this.stageFilter = this.stageFilter;
+            })
+            .catch(error => {
+                // eslint-disable-next-line no-console
+                console.error(error);
+            });
+    }
+
+    saveStatus() {
+        updateCaseStatus({ caseId: this.selectedCaseId, newStatus: this.newStatus })
+            .then(() => {
+                this.showStatusModal = false;
+                this.stageFilter = this.stageFilter;
+            })
+            .catch(error => {
+                // eslint-disable-next-line no-console
+                console.error(error);
+            });
+    }
+
+    sendRequest() {
+        const ccIds = this.ccUsers ? this.ccUsers.split(',').map(x => x.trim()) : [];
+        createBankRequest({ opportunityId: this.selectedDeal.opportunityId, bankAccountId: this.bank, ccUserIds: ccIds, subject: this.subject, body: this.body })
+            .then(() => {
+                this.showRequestModal = false;
+                this.stageFilter = this.stageFilter;
+            })
+            .catch(error => {
+                // eslint-disable-next-line no-console
+                console.error(error);
+            });
+    }
+}

--- a/force-app/main/default/lwc/dealManager/dealManager.js-meta.xml
+++ b/force-app/main/default/lwc/dealManager/dealManager.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata" fqn="dealManager">
+    <apiVersion>58.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/loanApplicationDashboard/loanApplicationDashboard.css
+++ b/force-app/main/default/lwc/loanApplicationDashboard/loanApplicationDashboard.css
@@ -1,0 +1,4 @@
+/* default styles */
+.slds-p-around_medium {
+    padding: 1rem;
+}

--- a/force-app/main/default/lwc/loanApplicationDashboard/loanApplicationDashboard.html
+++ b/force-app/main/default/lwc/loanApplicationDashboard/loanApplicationDashboard.html
@@ -1,0 +1,5 @@
+<template>
+    <lightning-card title="Loan Application Dashboard">
+        <p class="slds-p-around_medium">Placeholder content.</p>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/loanApplicationDashboard/loanApplicationDashboard.js
+++ b/force-app/main/default/lwc/loanApplicationDashboard/loanApplicationDashboard.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class LoanApplicationDashboard extends LightningElement {}

--- a/force-app/main/default/lwc/loanApplicationDashboard/loanApplicationDashboard.js-meta.xml
+++ b/force-app/main/default/lwc/loanApplicationDashboard/loanApplicationDashboard.js-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata" fqn="loanApplicationDashboard">
+    <apiVersion>58.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+    </targets>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- add `loanApplicationDashboard` LWC placeholder with non-empty CSS to avoid deploy errors
- clear input fields whenever a modal closes so subsequent requests start blank

## Testing
- `node --check force-app/main/default/lwc/dealManager/dealManager.js`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685342ac7a5c83329ec353401ddee95e